### PR TITLE
Add Gallium XA toggle

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,7 +39,7 @@ if [ -n "$_mesa_commit" ]; then
 fi
 
 pkgdesc="an open-source implementation of the OpenGL specification, git version"
-pkgver=20.2.0_devel.125531.849227d70f3
+pkgver=20.2.0_devel.125696.9e2afe4f05a
 pkgrel=1
 arch=('x86_64')
 makedepends=('git' 'python-mako' 'xorgproto' 'libxml2' 'libx11' 'libvdpau' 'libva' 'elfutils'
@@ -331,7 +331,7 @@ build () {
        -D gallium-opencl=icd \
        -D gallium-va=${_enabled_} \
        -D gallium-vdpau=${_enabled_} \
-       -D gallium-xa=${_enabled_} \
+       -D gallium-xa=${_gallium_xa} \
        -D gallium-xvmc=${_disabled_} \
        -D gbm=${_enabled_} \
        -D gles1=${_disabled_} \
@@ -390,7 +390,7 @@ build () {
           -D gallium-opencl=${_disabled_} \
           -D gallium-va=${_enabled_} \
           -D gallium-vdpau=${_enabled_} \
-          -D gallium-xa=${_enabled_} \
+          -D gallium-xa=${_gallium_xa} \
           -D gallium-xvmc=${_disabled_} \
           -D gbm=${_enabled_} \
           -D gles1=${_disabled_} \

--- a/customization.cfg
+++ b/customization.cfg
@@ -6,7 +6,7 @@
 # External config file to use - If the given file exists in path, it will override default config (customization.cfg) - Default is ~/.config/frogminer/mesa-git.cfg
 _EXT_CONFIG_PATH=~/.config/frogminer/mesa-git.cfg
 
-# Uncomment the MESA_WHICH_LLVM variable below to select which llvm package tree to use by default to build mesa-git against.
+# Uncomment the MESA_WHICH_LLVM variable below to select which LLVM package tree to use by default to build mesa-git against.
 # Note that if you're used to have that variable set in ~/.bashrc, you can leave it commented out here. It'll be respected by the PKGBUILD.
 # Else, you'll get prompted about it at build time.
 #
@@ -16,47 +16,49 @@ _EXT_CONFIG_PATH=~/.config/frogminer/mesa-git.cfg
 # 4  llvm (stable from extra) Default value
 MESA_WHICH_LLVM=4
 
-# Custom GCC root dir - Leave empty to use system compilers
+# Custom GCC root dir - Leave empty to use system compilers.
 # Example: CUSTOM_GCC_PATH="/home/frog/PKGBUILDS/mostlyportable-gcc/gcc-mostlyportable-9.2.0"
 CUSTOM_GCC_PATH=""
 
-# Enable lib32
+# Enable lib32.
 _lib32=true
 
-# Use local glesv2.pc - This is provided by libglvnd as of ab9b5fcc3bf90064418f6915cf4259fa11ffe64b
+# Use local glesv2.pc - This is provided by libglvnd as of ab9b5fcc3bf90064418f6915cf4259fa11ffe64b.
 _localglesv2pc=false
 
-# Use local egl.pc - This is provided by libglvnd as of ab9b5fcc3bf90064418f6915cf4259fa11ffe64b
+# Use local egl.pc - This is provided by libglvnd as of ab9b5fcc3bf90064418f6915cf4259fa11ffe64b.
 _localeglpc=false
 
-# Which dri drivers to include in the build - Default is "i915,i965,r100,r200,nouveau"
+# Which DRI drivers to include in the build - default is "i915,i965,r100,r200,nouveau".
 _dri_drivers="i915,i965,r100,r200,nouveau"
 
-# Which gallium drivers to include in the build - Default is "r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink"
+# Which Gallium drivers to include in the build - default is "r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink".
 _gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink"
 
-# Which vulkan drivers to include in the build - Default is "amd,intel"
+# Which Vulkan drivers to include in the build - default is "amd,intel".
 _vulkan_drivers="amd,intel"
 
-# Custom optimization flags - optional
+# Whether to build Gallium XA tracker - set to "false" to disable.
+#_gallium_xa="false"
+
+# Custom optimization flags - optional.
 #_custom_opt_flags="-march=native -O3 -fno-tree-vectorize"
 
-# Disable `-D b_lto=true` that Arch-meson passes by default - Set to "false" to enable LTO
+# Disable `-D b_lto=true` that Arch-meson passes by default - set to "false" to enable LTO.
 _no_lto="true"
 
-
-# custom mesa commit to pass to git
+# Custom Mesa commit to pass to Git.
 _mesa_commit=""
 
-# Use pending mesa merge requests directly as userpatches with their PR id, separated by space (example: "2421 3151 3273")
+# Use pending Mesa merge requests directly as userpatches with their PR ID, separated by space (example: "2421 3151 3273").
 # https://gitlab.freedesktop.org/mesa/mesa/merge_requests
 _mesa_prs=""
 
 
 #### USER PATCHES ####
 
-# community patches - add patches (separated by a space) of your choice by name from the community-patches dir
-# example: _community_patches="intel_haswell_vk_workaround.mymesarevert VK_JOSH_depth_bias_info_header.mymesapatch VK_JOSH_depth_bias_info_radv.mymesapatch"
+# Community patches - add patches (separated by a space) of your choice by name from the community-patches dir.
+# Example: _community_patches="intel_haswell_vk_workaround.mymesarevert VK_JOSH_depth_bias_info_header.mymesapatch VK_JOSH_depth_bias_info_radv.mymesapatch".
 _community_patches=""
 
 # You can use your own patches by putting them in the same folder as the PKGBUILD and giving them the .mymesapatch extension.


### PR DESCRIPTION
Added toggle to enable/disable Gallium XA tracker – disabling it allows me to skip building some drivers that I don't need saving time and space, so might be useful. :)

While at it, I made slight adjustments to the comments in `customization.cfg`.