### PR TITLE
Update customization.cfg

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -35,8 +35,8 @@ _localeglpc=false
 # Which DRI drivers to include in the build - default is "i915,i965,r100,r200,nouveau".
 _dri_drivers="i915,i965,r100,r200,nouveau"
 
-# Which Gallium drivers to include in the build - default is "r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink".
-_gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink"
+# Which Gallium drivers to include in the build - default is "r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink,crocus".
+_gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,swr,virgl,iris,zink,crocus"
 
 # Which Vulkan drivers to include in the build - default is "amd,intel".
 _vulkan_drivers="amd,intel"


### PR DESCRIPTION
Hi! The last mesa-git drivers has the new crocus driver for Intel Gen4-gen7 gallium
I tried to enable it and works good for my intel hd4000 :)  (Tried using dxvk and force loading crocus and all ok)
Edit for enabling default at build (It's not enabled by default)
For using at runtime it's in a export variable MESA_LOADER_DRIVER_OVERRIDE=crocus
Thanks