### PR TITLE
Disable meson pager

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -454,7 +454,7 @@ build () {
        -D zstd=auto \
        -D valgrind=${_enabled_} $_legacy_switches $_microsoft_clc $_xvmc $_layers $_optional_codecs $_no_lto $_additional_meson_flags $_additional_meson_flags_64
        
-    meson configure _build64
+    meson configure _build64 --no-pager
 
     # quoted from https://www.mesa3d.org/meson.html
     # Note: autotools automatically updated translation files (used by the DRI configuration tool) as part of the build process, Meson does not do this. 
@@ -513,7 +513,7 @@ build () {
           -D zstd=auto \
           -D valgrind=${_disabled_} $_legacy_switches $_microsoft_clc $_xvmc $_layers $_optional_codecs $_no_lto $_additional_meson_flags $_additional_meson_flags_32
        
-      meson configure _build32
+      meson configure _build32 --no-pager
 
       # quoted from https://www.mesa3d.org/meson.html
       # Note: autotools automatically updated translation files (used by the DRI configuration tool) as part of the build process, Meson does not do this. 


### PR DESCRIPTION
Starting from 0.64.0 [Meson uses pager by default](https://mesonbuild.com/Release-notes-for-0-64-0.html#pager-and-colors-for-meson-configure-output). It halts any building progress until you quit the configuration pager, which isn't great if you compile mesa unattended.

I have added `--no-pager` option to both `meson configure`s which disables the pager and starts building process as soon as its ready. It still outputs the entire configuration into the terminal as it did before.