### PR TITLE
Update customization.cfg to include the i915g driver

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -35,10 +35,11 @@ _localglesv2pc=false
 # Use local egl.pc - This is provided by libglvnd as of ab9b5fcc3bf90064418f6915cf4259fa11ffe64b.
 _localeglpc=false
 
-# Which Gallium drivers to include in the build - default is "r300,r600,radeonsi,nouveau,svga,swrast,virgl,iris,zink,crocus".
+# Which Gallium drivers to include in the build - default is "r300,r600,radeonsi,nouveau,svga,swrast,virgl,iris,zink,crocus,i915".
 # As of mesa commit e2de00876a7033b6923f912af8d2b0bbd100e113, swr (which was part of that default list) was removed. You can add it back if building an older commit.
 # For users with a dedicated AMD GPU (RX 400 series and newer) the minimum required to get a working display driver is the "radeonsi,svga,swrast" combo
-_gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,virgl,iris,zink,crocus"
+# If you experience build issues, try removing i915 to disable support for Gen 3 Intel hardware (GMA 950, GMA 3150, etc)
+_gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,virgl,iris,zink,crocus,i915"
 
 # Which patent encumbered codecs to build support for - default is "vc1dec,h264dec,h264enc,h265dec,h265enc" (all of them)
 # This is used for all video APIs (vaapi, vdpau, vulkan).


### PR DESCRIPTION
Has some bugs, but it's better than having to use llvmpipe. [This also matches the upstream package](https://github.com/archlinux/svntogit-packages/commit/ef78d43c8ed56325fc1df8c389e2204cb5b5d3cc). [For a period of time in 22.3](https://gitlab.freedesktop.org/mesa/mesa/-/issues/7782) having this driver caused build problems, so I've included a disclaimer to remove the driver if needed to deal with upstream Mesa changes. Right now it builds fine.