### PR TITLE
Depends: Python-yaml requred for u_format tables

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,7 +51,7 @@ makedepends=('git' 'python-mako' 'python-ply' 'xorgproto' 'libxml2' 'libx11' 'li
              'wayland-protocols' 'meson' 'ninja' 'libdrm' 'xorgproto' 'libdrm' 'libxshmfence' 
              'libxxf86vm' 'libxdamage' 'libclc' 'libglvnd' 'libunwind' 'lm_sensors' 'libxrandr'
              'valgrind' 'glslang' 'byacc' 'wget' 'flex' 'bison' 'rust' 'rust-bindgen' 'spirv-llvm-translator'
-             'cbindgen' 'python-packaging')
+             'cbindgen' 'python-packaging','python-yaml')
 
 if [ "$_lib32" == "true" ]; then
   makedepends+=('lib32-libxml2' 'lib32-libx11' 'lib32-libdrm' 'lib32-libxshmfence' 'lib32-libxxf86vm'


### PR DESCRIPTION
Python-yaml is needed for building according to https://gitlab.freedesktop.org/mesa/mesa/-/commit/bed6e0d6