### PR TITLE
Fix 32-bit build

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -522,6 +522,7 @@ build () {
         export CXX="g++ -m32"
       fi
       export PKG_CONFIG=/usr/bin/i686-pc-linux-gnu-pkg-config
+      export BINDGEN_EXTRA_CLANG_ARGS="--target=i686-unknown-linux-gnu"
 
       arch-meson $_mesa_srcdir _build32 \
           --cross-file lib32 \


### PR DESCRIPTION
Meson doesn't pass `BINDGEN_EXTRA_CLANG_ARGS` to Rust, causing the 32-bit build to fail.

Related issues:

* [mesa/11735](https://gitlab.freedesktop.org/mesa/mesa/-/issues/11735)
* [meson/13591](https://github.com/mesonbuild/meson/issues/13591)