### PR TITLE
Force fallback for venus-protocol

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -529,7 +529,7 @@ build () {
 
     arch-meson $_mesa_srcdir _build64 \
        --wrap-mode=nofallback \
-       --force-fallback-for=syn,paste,rustc-hash \
+       --force-fallback-for=syn,paste,rustc-hash,venus-protocol \
        -D b_ndebug=true \
        -D platforms=${_platforms} \
        -D gallium-drivers=${_gallium_drivers} \
@@ -600,7 +600,7 @@ build () {
           ${_crossfile_flag} \
           --libdir=/usr/lib32 \
           --wrap-mode=nofallback \
-          --force-fallback-for=syn,paste,rustc-hash \
+          --force-fallback-for=syn,paste,rustc-hash,venus-protocol \
           -D b_ndebug=true \
           -D platforms=${_platforms} \
           -D gallium-drivers=${_gallium_drivers} \


### PR DESCRIPTION
Recent [MR 43406](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/43406) over at mesa broke building drivers that use venus as `venus-protocol` is now not in-tree and is pulled as a subproject instead. This PR adds `venus-protocol` as a forced fallback so meson pulls venus subproject and builds. I have built successfully with this applied.

I am not *entirely* sure if this is the correct way to approach this, perhaps this should've been gated behind `c7919be1fa9d99a75eb6ec6042fdff6265fe55e5` commit ancestor? Though forced fallbacks aren't gated behind in the first place, so perhaps we should be fine, maybe? Let me know if there is anything that needs changing! 🐸